### PR TITLE
Migrate from master-slave vocabulary

### DIFF
--- a/common/tests.py
+++ b/common/tests.py
@@ -214,9 +214,9 @@ class CheckTest(TestCase):
         self.superuser1 = User(username='test_user', display='中文显示', is_active=True, is_superuser=True,
                                email='XXX@xxx.com')
         self.superuser1.save()
-        self.slave1 = Instance(instance_name='some_name', host='some_host', type='slave', db_type='mysql',
+        self.subordinate1 = Instance(instance_name='some_name', host='some_host', type='subordinate', db_type='mysql',
                                user='some_user', port=1234, password='some_password')
-        self.slave1.save()
+        self.subordinate1.save()
 
     def tearDown(self):
         self.superuser1.delete()
@@ -317,7 +317,7 @@ class CheckTest(TestCase):
         _get_engine.return_value.get_connection = _conn
         c = Client()
         c.force_login(self.superuser1)
-        r = c.post('/check/instance/', data={'instance_id': self.slave1.id})
+        r = c.post('/check/instance/', data={'instance_id': self.subordinate1.id})
         r_json = r.json()
         self.assertEqual(r_json['status'], 0)
 
@@ -366,9 +366,9 @@ class ChartTest(TestCase):
         cls.superuser1 = User(username='super1', is_superuser=True)
         cls.superuser1.save()
         cls.now = datetime.datetime.now()
-        cls.slave1 = Instance(instance_name='test_slave_instance', type='slave', db_type='mysql',
+        cls.subordinate1 = Instance(instance_name='test_subordinate_instance', type='subordinate', db_type='mysql',
                               host='testhost', port=3306, user='mysql_user', password='mysql_password')
-        cls.slave1.save()
+        cls.subordinate1.save()
         # 批量创建数据 ddl ,u1 ,g1, yesterday 组, 2 个数据
         ddl_workflow = [SqlWorkflow(
             workflow_name='ddl %s' % i,
@@ -380,7 +380,7 @@ class ChartTest(TestCase):
             create_time=cls.now - datetime.timedelta(days=1),
             status='workflow_finish',
             is_backup=True,
-            instance=cls.slave1,
+            instance=cls.subordinate1,
             db_name='some_db',
             syntax_type=1
         ) for i in range(2)]
@@ -395,7 +395,7 @@ class ChartTest(TestCase):
             create_time=cls.now - datetime.timedelta(days=2),
             status='workflow_finish',
             is_backup=True,
-            instance=cls.slave1,
+            instance=cls.subordinate1,
             db_name='some_db',
             syntax_type=2
         ) for i in range(3)]
@@ -424,7 +424,7 @@ class ChartTest(TestCase):
         cls.u1.delete()
         cls.u2.delete()
         cls.superuser1.delete()
-        cls.slave1.delete()
+        cls.subordinate1.delete()
 
     def testGetDateList(self):
         dao = ChartDao()

--- a/sql/binlog.py
+++ b/sql/binlog.py
@@ -62,7 +62,7 @@ def del_binlog(request):
 
     if binlog:
         query_engine = get_engine(instance=instance)
-        query_result = query_engine.query(sql=fr"purge master logs to '{binlog}';")
+        query_result = query_engine.query(sql=fr"purge main logs to '{binlog}';")
         if query_result.error is None:
             result = {'status': 0, 'msg': '清理成功', 'data': ''}
         else:

--- a/sql/completer/tests.py
+++ b/sql/completer/tests.py
@@ -23,13 +23,13 @@ class TestCompleter(TestCase):
         :return:
         """
         # 使用 travis.ci 时实例和测试service保持一致
-        cls.master = Instance(instance_name='test_instance', type='master', db_type='mysql',
+        cls.main = Instance(instance_name='test_instance', type='main', db_type='mysql',
                               host=settings.DATABASES['default']['HOST'],
                               port=settings.DATABASES['default']['PORT'],
                               user=settings.DATABASES['default']['USER'],
                               password=settings.DATABASES['default']['PASSWORD'])
-        cls.master.save()
-        cls.comp_engine = get_comp_engine(instance=cls.master, db_name=settings.DATABASES['default']['TEST']['NAME'])
+        cls.main.save()
+        cls.comp_engine = get_comp_engine(instance=cls.main, db_name=settings.DATABASES['default']['TEST']['NAME'])
         # 等待completion_refresher刷新完成
         while cls.comp_engine.completion_refresher.is_refreshing():
             import time
@@ -40,7 +40,7 @@ class TestCompleter(TestCase):
         """
         :return:
         """
-        cls.master.delete()
+        cls.main.delete()
         cls.comp_engine.refresh_completions(reset=True)
 
     def test_table_names_after_from(self):

--- a/sql/engines/mssql.py
+++ b/sql/engines/mssql.py
@@ -26,10 +26,10 @@ client charset = UTF-8;connect timeout=10;CHARSET={4};""".format(self.host, self
 
     def get_all_databases(self):
         """获取数据库列表, 返回一个ResultSet"""
-        sql = "SELECT name FROM master.sys.databases"
+        sql = "SELECT name FROM main.sys.databases"
         result = self.query(sql=sql)
         db_list = [row[0] for row in result.rows
-                   if row[0] not in ('master', 'msdb', 'tempdb', 'model')]
+                   if row[0] not in ('main', 'msdb', 'tempdb', 'model')]
         result.rows = db_list
         return result
 

--- a/sql/engines/mysql.py
+++ b/sql/engines/mysql.py
@@ -40,9 +40,9 @@ class MysqlEngine(EngineBase):
         return 'MySQL engine'
 
     @property
-    def seconds_behind_master(self):
-        slave_status = self.query(sql='show slave status')
-        return slave_status.rows[0][32] if slave_status.rows else None
+    def seconds_behind_main(self):
+        subordinate_status = self.query(sql='show subordinate status')
+        return subordinate_status.rows[0][32] if subordinate_status.rows else None
 
     @property
     def server_version(self):

--- a/sql/engines/tests.py
+++ b/sql/engines/tests.py
@@ -32,7 +32,7 @@ class TestEngineBase(TestCase):
     def setUpClass(cls):
         cls.u1 = User(username='some_user', display='用户1')
         cls.u1.save()
-        cls.ins1 = Instance(instance_name='some_ins', type='master', db_type='mssql', host='some_host',
+        cls.ins1 = Instance(instance_name='some_ins', type='main', db_type='mssql', host='some_host',
                             port=1366, user='ins_user', password='some_pass')
         cls.ins1.save()
         cls.wf1 = SqlWorkflow.objects.create(
@@ -74,7 +74,7 @@ class TestMssql(TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.ins1 = Instance(instance_name='some_ins', type='slave', db_type='mssql', host='some_host',
+        cls.ins1 = Instance(instance_name='some_ins', type='subordinate', db_type='mssql', host='some_host',
                             port=1366, user='ins_user', password='some_pass')
         cls.ins1.save()
         cls.engine = MssqlEngine(instance=cls.ins1)
@@ -218,7 +218,7 @@ class TestMssql(TestCase):
 class TestMysql(TestCase):
 
     def setUp(self):
-        self.ins1 = Instance(instance_name='some_ins', type='slave', db_type='mysql', host='some_host',
+        self.ins1 = Instance(instance_name='some_ins', type='subordinate', db_type='mysql', host='some_host',
                              port=1366, user='ins_user', password='some_pass')
         self.ins1.save()
         self.sys_config = SysConfig()
@@ -488,16 +488,16 @@ class TestMysql(TestCase):
         _query.assert_called_once_with(sql="kill 100")
 
     @patch.object(MysqlEngine, 'query')
-    def test_seconds_behind_master(self, _query):
+    def test_seconds_behind_main(self, _query):
         new_engine = MysqlEngine(instance=self.ins1)
-        new_engine.seconds_behind_master()
-        _query.assert_called_once_with(sql="show slave status")
+        new_engine.seconds_behind_main()
+        _query.assert_called_once_with(sql="show subordinate status")
 
 
 class TestRedis(TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.ins = Instance(instance_name='some_ins', type='slave', db_type='redis', host='some_host',
+        cls.ins = Instance(instance_name='some_ins', type='subordinate', db_type='redis', host='some_host',
                            port=1366, user='ins_user', password='some_pass')
         cls.ins.save()
 
@@ -621,7 +621,7 @@ class TestRedis(TestCase):
 class TestPgSQL(TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.ins = Instance(instance_name='some_ins', type='slave', db_type='pgsql', host='some_host',
+        cls.ins = Instance(instance_name='some_ins', type='subordinate', db_type='pgsql', host='some_host',
                            port=1366, user='ins_user', password='some_pass')
         cls.ins.save()
 
@@ -760,9 +760,9 @@ class TestModel(TestCase):
 
 class TestInception(TestCase):
     def setUp(self):
-        self.ins = Instance.objects.create(instance_name='some_ins', type='slave', db_type='mysql', host='some_host',
+        self.ins = Instance.objects.create(instance_name='some_ins', type='subordinate', db_type='mysql', host='some_host',
                                            port=3306, user='ins_user', password='some_pass')
-        self.ins_inc = Instance.objects.create(instance_name='some_ins_inc', type='slave', db_type='inception',
+        self.ins_inc = Instance.objects.create(instance_name='some_ins_inc', type='subordinate', db_type='inception',
                                                host='some_host', port=6669)
         self.wf = SqlWorkflow.objects.create(
             workflow_name='some_name',
@@ -956,10 +956,10 @@ class TestInception(TestCase):
 
 class TestGoInception(TestCase):
     def setUp(self):
-        self.ins = Instance.objects.create(instance_name='some_ins', type='slave', db_type='mysql',
+        self.ins = Instance.objects.create(instance_name='some_ins', type='subordinate', db_type='mysql',
                                            host='some_host',
                                            port=3306, user='ins_user', password='some_pass')
-        self.ins_inc = Instance.objects.create(instance_name='some_ins_inc', type='slave', db_type='goinception',
+        self.ins_inc = Instance.objects.create(instance_name='some_ins_inc', type='subordinate', db_type='goinception',
                                                host='some_host', port=4000)
         self.wf = SqlWorkflow.objects.create(
             workflow_name='some_name',
@@ -1102,7 +1102,7 @@ class TestOracle(TestCase):
     """Oracle 测试"""
 
     def setUp(self):
-        self.ins = Instance.objects.create(instance_name='some_ins', type='slave', db_type='oracle',
+        self.ins = Instance.objects.create(instance_name='some_ins', type='subordinate', db_type='oracle',
                                            host='some_host', port=3306, user='ins_user', password='some_pass',
                                            sid='some_id')
         self.wf = SqlWorkflow.objects.create(

--- a/sql/migrations/0001_initial.py
+++ b/sql/migrations/0001_initial.py
@@ -258,7 +258,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
                 ('instance_name', models.CharField(max_length=50, unique=True, verbose_name='实例名称')),
-                ('type', models.CharField(choices=[('master', '主库'), ('slave', '从库')], max_length=6, verbose_name='实例类型')),
+                ('type', models.CharField(choices=[('main', '主库'), ('subordinate', '从库')], max_length=6, verbose_name='实例类型')),
                 ('db_type', models.CharField(choices=[('mysql', 'MySQL'), ('mssql', 'MsSQL'), ('redis', 'Redis'), ('pgsql', 'PgSQL'), ('oracle', 'Oracle'), ('inception', 'Inception'), ('goinception', 'goInception')], max_length=20, verbose_name='数据库类型')),
                 ('host', models.CharField(max_length=200, verbose_name='实例连接')),
                 ('port', models.IntegerField(default=0, verbose_name='端口')),

--- a/sql/models.py
+++ b/sql/models.py
@@ -40,7 +40,7 @@ class Instance(models.Model):
     各个线上实例配置
     """
     instance_name = models.CharField('实例名称', max_length=50, unique=True)
-    type = models.CharField('实例类型', max_length=6, choices=(('master', '主库'), ('slave', '从库')))
+    type = models.CharField('实例类型', max_length=6, choices=(('main', '主库'), ('subordinate', '从库')))
     db_type = models.CharField('数据库类型', max_length=20, choices=DB_TYPE_CHOICES)
     host = models.CharField('实例连接', max_length=200)
     port = models.IntegerField('端口', default=0)

--- a/sql/query.py
+++ b/sql/query.py
@@ -139,8 +139,8 @@ def query(request):
 
         # 仅将成功的查询语句记录存入数据库
         if not query_result.error:
-            if hasattr(query_engine, 'seconds_behind_master'):
-                result['data']['seconds_behind_master'] = query_engine.seconds_behind_master
+            if hasattr(query_engine, 'seconds_behind_main'):
+                result['data']['seconds_behind_main'] = query_engine.seconds_behind_main
             if int(limit_num) == 0:
                 limit_num = int(query_result.affected_rows)
             else:

--- a/sql/utils/data_masking.py
+++ b/sql/utils/data_masking.py
@@ -91,7 +91,7 @@ def analyze_query_tree(query_tree, instance):
             for
             select_item in select_list if select_item['type'] in ('FIELD_ITEM', 'aggregate')]
 
-        # 处理select_list，为统一的{'type': 'FIELD_ITEM', 'db': 'archery_master', 'table': 'sql_users', 'field': 'email'}格式
+        # 处理select_list，为统一的{'type': 'FIELD_ITEM', 'db': 'archery_main', 'table': 'sql_users', 'field': 'email'}格式
         select_list = [select_item if select_item['type'] == 'FIELD_ITEM' else select_item['aggregate'] for
                        select_item in select_list if select_item['type'] in ('FIELD_ITEM', 'aggregate')]
 

--- a/sql/utils/resource_group.py
+++ b/sql/utils/resource_group.py
@@ -20,7 +20,7 @@ def user_instances(user, type=None, db_type=None, tag_codes=None):
     """
     获取用户实例列表（通过资源组间接关联）
     :param user:
-    :param type: 实例类型 all：全部，master主库，salve从库
+    :param type: 实例类型 all：全部，main主库，salve从库
     :param db_type: 数据库类型, ['mysql','mssql']
     :param tag_codes: 标签code列表, ['can_write', 'can_read']
     :return:

--- a/sql/utils/tests.py
+++ b/sql/utils/tests.py
@@ -139,12 +139,12 @@ class TestSQLReview(TestCase):
         self.superuser = User.objects.create(username='super', is_superuser=True)
         self.user = User.objects.create(username='user')
         # 使用 travis.ci 时实例和测试service保持一致
-        self.master = Instance(instance_name='test_instance', type='master', db_type='mysql',
+        self.main = Instance(instance_name='test_instance', type='main', db_type='mysql',
                                host=settings.DATABASES['default']['HOST'],
                                port=settings.DATABASES['default']['PORT'],
                                user=settings.DATABASES['default']['USER'],
                                password=settings.DATABASES['default']['PASSWORD'])
-        self.master.save()
+        self.main.save()
         self.sys_config = SysConfig()
         self.client = Client()
         self.group = ResourceGroup.objects.create(group_id=1, group_name='group_name')
@@ -158,7 +158,7 @@ class TestSQLReview(TestCase):
             create_time=datetime.datetime.now(),
             status='workflow_review_pass',
             is_backup=True,
-            instance=self.master,
+            instance=self.main,
             db_name='db_name',
             syntax_type=1,
         )
@@ -173,7 +173,7 @@ class TestSQLReview(TestCase):
         self.group.delete()
         self.superuser.delete()
         self.user.delete()
-        self.master.delete()
+        self.main.delete()
         self.sys_config.replace(json.dumps({}))
 
     @patch('sql.engines.get_engine')
@@ -471,7 +471,7 @@ class TestSQLReview(TestCase):
 
 class TestExecuteSql(TestCase):
     def setUp(self):
-        self.ins = Instance.objects.create(instance_name='some_ins', type='slave', db_type='mysql',
+        self.ins = Instance.objects.create(instance_name='some_ins', type='subordinate', db_type='mysql',
                                            host='some_host',
                                            port=3306, user='ins_user', password='some_pass')
         self.wf = SqlWorkflow.objects.create(
@@ -638,7 +638,7 @@ class TestAudit(TestCase):
         self.user = User.objects.create(username='test_user', display='中文显示', is_active=True)
         self.su = User.objects.create(username='s_user', display='中文显示', is_active=True, is_superuser=True)
         tomorrow = datetime.datetime.today() + datetime.timedelta(days=1)
-        self.ins = Instance.objects.create(instance_name='some_ins', type='slave', db_type='mysql',
+        self.ins = Instance.objects.create(instance_name='some_ins', type='subordinate', db_type='mysql',
                                            host='some_host',
                                            port=3306, user='ins_user', password='some_pass')
         self.wf = SqlWorkflow.objects.create(
@@ -1057,7 +1057,7 @@ class TestDataMasking(TestCase):
     def setUp(self):
         self.superuser = User.objects.create(username='super', is_superuser=True)
         self.user = User.objects.create(username='user')
-        self.ins = Instance.objects.create(instance_name='some_ins', type='slave', db_type='mysql',
+        self.ins = Instance.objects.create(instance_name='some_ins', type='subordinate', db_type='mysql',
                                            host='some_host',
                                            port=3306, user='ins_user', password='some_pass')
         self.sys_config = SysConfig()
@@ -1265,10 +1265,10 @@ class TestResourceGroup(TestCase):
         self.sys_config = SysConfig()
         self.user = User.objects.create(username='test_user', display='中文显示', is_active=True)
         self.su = User.objects.create(username='s_user', display='中文显示', is_active=True, is_superuser=True)
-        self.ins1 = Instance.objects.create(instance_name='some_ins1', type='slave', db_type='mysql',
+        self.ins1 = Instance.objects.create(instance_name='some_ins1', type='subordinate', db_type='mysql',
                                             host='some_host',
                                             port=3306, user='ins_user', password='some_pass')
-        self.ins2 = Instance.objects.create(instance_name='some_ins2', type='slave', db_type='mysql',
+        self.ins2 = Instance.objects.create(instance_name='some_ins2', type='subordinate', db_type='mysql',
                                             host='some_host',
                                             port=3306, user='ins_user', password='some_pass')
         self.rgp1 = ResourceGroup.objects.create(group_name='group1')

--- a/themis/utils/wtform_models.py
+++ b/themis/utils/wtform_models.py
@@ -88,12 +88,12 @@ class SimpleForm(BaseForm):
 
     def validate_rule_cmd(form, field):
         db_key = ("\b(exec|execute|insert|select|delete|update|alter|create|"
-                  "drop|count|chr|char|asc|mid|substring|master|truncate|"
+                  "drop|count|chr|char|asc|mid|substring|main|truncate|"
                   "declare|xp_cmdshell|restore|backup|net)\b")
         mongo_key = r"""\b(update|delete|drop|remove|killcursors|dropdatabase
                         |dropindex|reindex|lock|unlock|fsync|setprofilingLevel
                         |repairDatabase|removeUser|shutdownServer|killOp|eval
-                        |copyDatabase|cloneDatabase|addUser|setSlaveOk)\b"""
+                        |copyDatabase|cloneDatabase|addUser|setSubordinateOk)\b"""
         regex = re.compile(mongo_key, re.I)
         m = regex.search(field.data)
         if m:

--- a/themis/views.py
+++ b/themis/views.py
@@ -125,7 +125,7 @@ class SqlReRuleSetInfoIndex(BaseHandler):
         任务发布界面之ip地址显示
         """
         # 获取实例列表
-        instances = Instance.objects.filter(type='master', db_type='mysql')
+        instances = Instance.objects.filter(type='main', db_type='mysql')
         return render(request, "rule_set_info.html", {'instances': instances})
 
 


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.